### PR TITLE
v3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Usage
                       [--doNotUseProvidedSoftware]
                       [--conservedSeq] [--extraSeq N] [--minCovPresence N]
                       [--minCovCall N] [--minFrequencyDominantAllele 0.6]
-                      [--minGeneCoverage N]
+                      [--minGeneCoverage N] [--doubleRun] [--debug]
                       [-a /path/to/asperaweb_id_dsa.openssh] [-k]
                       [--downloadLibrariesType PAIRED]
                       [--downloadInstrumentPlatform ILLUMINA] [--downloadCramBam]
@@ -94,6 +94,12 @@ Usage
       --minGeneCoverage N   Minimum percentage of target reference gene sequence covered
                             by --minCovPresence to consider a gene to be present
                             (value between [0, 100]) (default: 80)
+      --doubleRun           Tells ReMatCh to run a second time using as reference the
+                            noMatter consensus sequence produced in the first run.
+                            This will improve consensus sequence determination for
+                            sequences with high percentage of target reference gene
+                            sequence covered (default: False)
+      --debug               DeBug Mode: do not remove temporary files (default: False)
 
     Download facultative options:
       -a /path/to/asperaweb_id_dsa.openssh, --asperaKey /path/to/asperaweb_id_dsa.openssh
@@ -123,6 +129,8 @@ Usage
       -t "Streptococcus agalactiae", --taxon "Streptococcus agalactiae"
                             Taxon name for which ReMatCh will download fastq files
                             (default: None)
+
+
 
 **Running ReMatCh in local samples**  
 To run ReMatCh in local fastq files, please organize those files in sample folders.  
@@ -164,11 +172,16 @@ ReMatCh running log file.
  - *sample_run_time* - Global sample running time
  - *download_run_successfully* - Reports whether the sample downloading (if requested) run successfully
  - *download_run_time* - Download running time
- - *rematch_run_successfully* - Reports whether the ReMatCh module run successfully
- - *rematch_run_time* - ReMatCh running time
- - *number_absent_genes* - Number of absent genes
- - *number_genes_multiple_alleles* - Number of genes with multiple alleles among the genes present
- - *mean_sample_coverage* - Mean sample coverage depth (only considering the genes present)
+ - *rematch_run_successfully_first* - Reports whether the first run of ReMatCh module run successfully
+ - *rematch_run_successfully_second* - Reports whether the second run of ReMatCh module run successfully
+ - *rematch_run_time_first* - ReMatCh first running time
+ - *rematch_run_time_second* - ReMatCh second running time
+ - *number_absent_genes_first* - Number of absent genes determined in the first ReMatch run
+ - *number_genes_multiple_alleles_first* - Number of genes with multiple alleles among the genes present determined in the first ReMatch run
+ - *mean_sample_coverage_first* - Mean sample coverage depth (only considering the genes present) determined in the first ReMatch run
+ - *number_absent_genes_second* - Number of absent genes determined in the second ReMatch run
+ - *number_genes_multiple_alleles_second* - Number of genes with multiple alleles among the genes present determined in the second ReMatch run
+ - *mean_sample_coverage_second* - Mean sample coverage depth (only considering the genes present) determined in the second ReMatch run
  - *run_accession* - ENA Run Accession number used to download
  - *instrument_platform* - Sequencing technology used reported by ENA
  - *instrument_model* - Instrument model used for sequencing reported by ENA
@@ -179,6 +192,7 @@ ReMatCh running log file.
  - *fastq_used* - Fastq files used in ReMatCh module
 
 **combined_report.data_by_gene.*.tab**  
+_combined_report.data_by_gene.first_run.\*.tab_ and _combined_report.data_by_gene.second_run.\*.tab_  
 This file contains a report with gene (in columns) presence/absence and coverage depth for the different samples (in lines).  
 In the case of genes being present (genes with at least `--minGeneCoverage` percentage of target reference gene sequence covered with `--minCovPresence` reads), the script will provide the mean target sequence coverage, otherwise will report "absent_" for genes not present.  
 In case of multiple alleles occurrence, if the frequency of the dominant allele is lower than `--minFrequencyDominantAllele` and the frequency of the most frequent minority allele is higher than 50% of the total of the minority alleles or is 50% but only 2 minority alleles exist, "multiAlleles_" will be reported.  
@@ -192,6 +206,8 @@ For each sample, three fasta files will be produced:
  - *sample.correct.fasta* - Fasta file containing the target gene sequence with the correct nucleotides. Positions with less than `--minCovPresence` coverage depth will be considered as deletions, with less than `--minCovCall` coverage depth will be coded as "N" (due to low certainty in calling SNP) and positions with possible multiple alleles will also be considered as "N".
  - *sample.alignment.fasta* - Will be exactly the same as *sample.correct.fasta*, but INDELs will be coded as "N" in order to produce sequences with the same size that can be then concatenated to produce an alignment file
  - *rematchModule_report.txt* - Report file containg gene information: 1) gene name, 2) percentage of target gene sequence covered with at least `--minCovPresence` read depth, 3) Mean target gene coverage depth of present positions, 4) percentage of target gene sequence with lower `--minCovCall` coverage depth, 5) number of positions in target gene sequence containing multiple alleles. The general sample information will also be stored: number of absent genes, number of genes with multiple alleles among the genes present and the mean sample coverage depth (only considering the genes present).
+ - *rematch_module/* - Folder containing the temporary files. Only kept if `--debug` option is specified. It will contain the *alignment.bam*, bam and fasta indexes, *sequence_data/* folder with subfolders (named with numbers) for each sequence in `--reference` file. In each sequence folder the different consensus _\*.vcf_ files and the original _samtools_mpileup.\*.vcf_ and _samtools_depth.\*.vcf_ files
+ - *rematch_second_run/* - Folder containing the same files/folders described above, but for the *second_run*. Only created if `--doubleRun` is set
 
 
 

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -194,8 +194,9 @@ def get_alt_noMatter(variant_position, indel_true):
 		if float(variant_position['info']['IDV']) / float(dp) > 0.5:
 			index_dominant_allele = variant_position['format']['AD'].index(str(max(map(int, variant_position['format']['AD']))))
 			if index_dominant_allele == 0:
-				sys.exit('Unexpected INDEL ALT coverage depth pattern found')
-				# alt = '.'
+				# sys.exit('Unexpected INDEL ALT coverage depth pattern found')
+				print '####################', variant_position, indel_true
+				alt = '.'
 			else:
 				alt = variant_position['ALT'][index_dominant_allele - 1]
 			ad_idv = int(variant_position['info']['IDV'])
@@ -279,6 +280,8 @@ def determine_variant(variant_position, minimum_depth_presence, minimum_depth_ca
 
 
 def confirm_nucleotides_indel(ref, alt, variants, position_start_indel, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele):
+	alt = list(alt)
+
 	for i in range(0, len(alt) - 1):
 		if alt[1 + i] == 'N':
 			continue
@@ -294,7 +297,8 @@ def confirm_nucleotides_indel(ref, alt, variants, position_start_indel, minimum_
 		new_ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[new_position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 		if alt_noMatter != '.' and alt[1 + i] != alt_noMatter:
 			alt[1 + i] = alt_noMatter
-	return alt
+
+	return ''.join(alt)
 
 
 def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele):
@@ -314,8 +318,11 @@ def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, mi
 		if alt_noMatter == '.':
 			ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 		else:
-			if alt_correct is not None and alt_correct_snp != '.' and alt_correct[0] != alt_correct_snp:
-				alt_correct = alt_correct_snp + alt_correct[1:] if len(alt_correct) > 1 else alt_correct_snp
+			if alt_correct is None and alt_correct_snp is not None:
+				alt_correct = alt_correct
+			elif alt_correct is not None and alt_correct_snp is not None:
+				if alt_correct_snp != '.' and alt_correct[0] != alt_correct_snp:
+					alt_correct = alt_correct_snp + alt_correct[1:] if len(alt_correct) > 1 else alt_correct_snp
 			if alt_noMatter_snp != '.' and alt_noMatter[0] != alt_noMatter_snp:
 				alt_noMatter = alt_noMatter_snp + alt_noMatter[1:] if len(alt_noMatter) > 1 else alt_noMatter_snp
 			if alt_alignment_snp != '.' and alt_alignment[0] != alt_alignment_snp:

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -280,20 +280,19 @@ def determine_variant(variant_position, minimum_depth_presence, minimum_depth_ca
 
 def confirm_nucleotides_indel(ref, alt, variants, position_start_indel, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele):
 	for i in range(0, len(alt) - 1):
+		if alt[1 + i] == 'N':
+			continue
+
 		if len(alt) < len(ref):
 			new_position = position_start_indel + len(alt) - i
-			ref_nucleotide = ref[len(alt) - i]
-		elif len(alt) > len(ref):
-			if i + 1 > len(ref):
+		else:
+			if i + 1 > len(ref) - 1:
 				break
 			new_position = position_start_indel + 1 + i
-			ref_nucleotide = ref[1 + i]
-		else:
-			sys.exit('INDEL expected, SNP found')
 
 		entry_with_indel, entry_with_snp = indel_entry(variants[new_position])
 		new_ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[new_position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
-		if ref_nucleotide != new_ref:
+		if alt_noMatter != '.' and alt[1 + i] != alt_noMatter:
 			alt[1 + i] = alt_noMatter
 	return alt
 
@@ -310,12 +309,12 @@ def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, mi
 		if len(entry_with_indel) > 1:
 			indel_more_likely = get_indel_more_likely(variants[position], entry_with_indel)
 
-		ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][entry_with_indel[indel_more_likely]], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, True)
+		ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][indel_more_likely], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, True)
 
 		if alt_noMatter == '.':
 			ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 		else:
-			if alt_correct_snp != '.' and alt_correct[0] != alt_correct_snp:
+			if alt_correct is not None and alt_correct_snp != '.' and alt_correct[0] != alt_correct_snp:
 				alt_correct = alt_correct_snp + alt_correct[1:] if len(alt_correct) > 1 else alt_correct_snp
 			if alt_noMatter_snp != '.' and alt_noMatter[0] != alt_noMatter_snp:
 				alt_noMatter = alt_noMatter_snp + alt_noMatter[1:] if len(alt_noMatter) > 1 else alt_noMatter_snp
@@ -324,9 +323,9 @@ def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, mi
 
 			if alt_noMatter != '.':
 				alt_noMatter = confirm_nucleotides_indel(ref, alt_noMatter, variants, position, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele)
-			if alt_correct is not None and alt_correct != '.' and not alt_correct.startswith('N'):
+			if alt_correct is not None and alt_correct != '.':
 				alt_correct = confirm_nucleotides_indel(ref, alt_correct, variants, position, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele)
-			if alt_alignment != '.' and not alt_alignment.startswith('N'):
+			if alt_alignment != '.':
 				alt_alignment = confirm_nucleotides_indel(ref, alt_alignment, variants, position, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele)
 
 	return ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -178,32 +178,38 @@ def indel_entry(variant_position):
 
 
 def get_alt_noMatter(variant_position, indel_true):
-	# dp = int(variant_position['info']['DP'])
 	dp = sum(map(int, variant_position['format']['AD']))
-	index_dominant_allele = None
+	index_alleles_sorted_position = [(position, depth) for depth, position in sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)]
+	index_dominant_allele = index_alleles_sorted_position[0][0]
 	if not indel_true:
-		ad_idv = max(map(int, variant_position['format']['AD']))
-
-		index_dominant_allele = variant_position['format']['AD'].index(str(ad_idv))
-
-		if index_dominant_allele == 0:
-			alt = '.'
-		else:
-			alt = variant_position['ALT'][index_dominant_allele - 1]
-	else:
-		if float(variant_position['info']['IDV']) / float(dp) >= 0.5:
-			index_alleles_sorted_position = [position for depth, position in sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)]
-			if index_alleles_sorted_position[0] == 0:
-				if float(variant_position['info']['IDV']) / float(dp) > 0.5:
-					alt = variant_position['ALT'][index_alleles_sorted_position[1] - 1]
+		ad_idv = index_alleles_sorted_position[0][1]
+		if float(ad_idv) / float(dp) >= 0.5:
+			if index_alleles_sorted_position[0][0] == 0:
+				if float(ad_idv) / float(dp) > 0.5:
+					alt = variant_position['ALT'][index_alleles_sorted_position[1][0] - 1]
+					index_dominant_allele = index_alleles_sorted_position[1][0]
 				else:
-					alt = '.'
+					alt = 'N'
+					index_dominant_allele = None
 			else:
-				alt = variant_position['ALT'][index_alleles_sorted_position[0] - 1]
-			ad_idv = int(variant_position['info']['IDV'])
+				alt = variant_position['ALT'][index_alleles_sorted_position[0][0] - 1]
 		else:
 			alt = '.'
-			ad_idv = max(map(int, variant_position['format']['AD']))
+	else:
+		ad_idv = int(variant_position['info']['IDV'])
+		if float(ad_idv) / float(dp) >= 0.5:
+			if index_alleles_sorted_position[0][0] == 0:
+				if float(ad_idv) / float(dp) > 0.5:
+					alt = variant_position['ALT'][index_alleles_sorted_position[1][0] - 1]
+					index_dominant_allele = index_alleles_sorted_position[1][0]
+				else:
+					alt = 'N'
+					index_dominant_allele = None
+			else:
+				alt = variant_position['ALT'][index_alleles_sorted_position[0][0] - 1]
+		else:
+			alt = '.'
+			ad_idv = index_alleles_sorted_position[0][1]
 
 	return alt, dp, ad_idv, index_dominant_allele
 

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -191,14 +191,15 @@ def get_alt_noMatter(variant_position, indel_true):
 		else:
 			alt = variant_position['ALT'][index_dominant_allele - 1]
 	else:
-		if float(variant_position['info']['IDV']) / float(dp) > 0.5:
-			index_dominant_allele = variant_position['format']['AD'].index(str(max(map(int, variant_position['format']['AD']))))
-			if index_dominant_allele == 0:
-				# sys.exit('Unexpected INDEL ALT coverage depth pattern found')
-				print '####################', variant_position, indel_true
-				alt = '.'
+		if float(variant_position['info']['IDV']) / float(dp) >= 0.5:
+			index_alleles_sorted_position = [position for depth, position in sorted(zip(map(int(variant_position['format']['AD'])), range(0, len(variant_position['format']['AD']))))]
+			if index_alleles_sorted_position[0] == 0:
+				if float(variant_position['info']['IDV']) / float(dp) > 0.5:
+					alt = variant_position['ALT'][index_alleles_sorted_position[1] - 1]
+				else:
+					alt = '.'
 			else:
-				alt = variant_position['ALT'][index_dominant_allele - 1]
+				alt = variant_position['ALT'][index_alleles_sorted_position[0] - 1]
 			ad_idv = int(variant_position['info']['IDV'])
 		else:
 			alt = '.'
@@ -307,7 +308,7 @@ def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, mi
 	if len(entry_with_indel) == 0:
 		ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 	else:
-		ref, alt_correct_snp, low_coverage, multiple_alleles, alt_noMatter_snp, alt_alignment_snp = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
+		ref_snp, alt_correct_snp, low_coverage_snp, multiple_alleles_snp, alt_noMatter_snp, alt_alignment_snp = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 
 		indel_more_likely = entry_with_indel[0]
 		if len(entry_with_indel) > 1:
@@ -316,10 +317,10 @@ def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, mi
 		ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][indel_more_likely], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, True)
 
 		if alt_noMatter == '.':
-			ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
+			ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = ref_snp, alt_correct_snp, low_coverage_snp, multiple_alleles_snp, alt_noMatter_snp, alt_alignment_snp
 		else:
 			if alt_correct is None and alt_correct_snp is not None:
-				alt_correct = alt_correct
+				alt_correct = alt_correct_snp
 			elif alt_correct is not None and alt_correct_snp is not None:
 				if alt_correct_snp != '.' and alt_correct[0] != alt_correct_snp:
 					alt_correct = alt_correct_snp + alt_correct[1:] if len(alt_correct) > 1 else alt_correct_snp

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -680,34 +680,11 @@ def gather_data_together(sample, data_directory, sequences_information, outdir, 
 	return run_successfully, sample_data, consensus_files
 
 
-def clean_headers_reference_file(reference_file, outdir):
-	print 'Checking if reference sequences contain | or spaces'
-	headers_changed = False
-	new_reference_file = reference_file
-	sequences = get_sequence_information(reference_file)
-	for i in sequences:
-		if any(x in sequences[i]['header'] for x in ['|', ' ']):
-			for x in ['|', ' ']:
-				sequences[i]['header'] = sequences[i]['header'].replace(x, '_')
-			headers_changed = True
-	if headers_changed:
-		print 'At least one of the those characters was found. Replacing those with _'
-		new_reference_file = os.path.join(outdir, os.path.splitext(os.path.basename(reference_file))[0] + '.headers_renamed.fasta')
-		with open(new_reference_file, 'rt') as writer:
-			writer.write('>' + sequences[i]['header'] + '\n')
-			fasta_sequence_lines = chunkstring(sequences[i]['sequence'], 80)
-			for line in fasta_sequence_lines:
-				writer.write(line + '\n')
-	return new_reference_file
-
-
 rematch_timer = functools.partial(utils.timer, name='ReMatCh module')
 
 
 @rematch_timer
 def runRematchModule(sample, fastq_files, reference_file, threads, outdir, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, minimum_gene_coverage, conserved_True, debug_mode_true):
-	reference_file = clean_headers_reference_file(reference_file, outdir)
-
 	rematch_folder = os.path.join(outdir, 'rematch_module', '')
 	utils.removeDirectory(rematch_folder)
 	os.mkdir(rematch_folder)

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -596,7 +596,7 @@ def get_sequence_information(fasta_file):
 	return sequence_dict
 
 
-def sequence_data(sample, reference_file, bam_file, outdir, threads, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele):
+def sequence_data(sample, reference_file, bam_file, outdir, threads, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, debug_mode_true):
 	sequence_data_outdir = os.path.join(outdir, 'sequence_data', '')
 	utils.removeDirectory(sequence_data_outdir)
 	os.mkdir(sequence_data_outdir)
@@ -633,7 +633,7 @@ def write_consensus(outdir, sample, consensus_sequence):
 	return consensus_files
 
 
-def gather_data_together(sample, data_directory, sequences_information, outdir):
+def gather_data_together(sample, data_directory, sequences_information, outdir, debug_mode_true):
 	run_successfully = True
 	counter = 0
 	sample_data = {}
@@ -665,7 +665,8 @@ def gather_data_together(sample, data_directory, sequences_information, outdir):
 					sample_data[sequence_counter] = {'header': sequences_information[sequence_counter]['header'], 'gene_coverage': 100 - percentage_absent, 'gene_low_coverage': percentage_lowCoverage, 'gene_number_positions_multiple_alleles': multiple_alleles_found, 'gene_mean_read_coverage': meanCoverage}
 					counter += 1
 
-		utils.removeDirectory(gene_dir_path)
+		if not debug_mode_true:
+			utils.removeDirectory(gene_dir_path)
 
 	if counter != len(sequences_information):
 		run_successfully = False
@@ -677,7 +678,7 @@ rematch_timer = functools.partial(utils.timer, name='ReMatCh module')
 
 
 @rematch_timer
-def runRematchModule(sample, fastq_files, reference_file, threads, outdir, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, minimum_gene_coverage, conserved_True):
+def runRematchModule(sample, fastq_files, reference_file, threads, outdir, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, minimum_gene_coverage, conserved_True, debug_mode_true):
 	rematch_folder = os.path.join(outdir, 'rematch_module', '')
 	utils.removeDirectory(rematch_folder)
 	os.mkdir(rematch_folder)
@@ -690,7 +691,7 @@ def runRematchModule(sample, fastq_files, reference_file, threads, outdir, lengt
 		run_successfully, stdout = index_fasta_samtools(reference_file, None, None, True)
 		if run_successfully:
 			print 'Analysing alignment data'
-			run_successfully, sample_data, consensus_files = sequence_data(sample, reference_file, bam_file, rematch_folder, threads, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele)
+			run_successfully, sample_data, consensus_files = sequence_data(sample, reference_file, bam_file, rematch_folder, threads, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, debug_mode_true)
 
 			if run_successfully:
 				print 'Writing report file'
@@ -718,6 +719,7 @@ def runRematchModule(sample, fastq_files, reference_file, threads, outdir, lengt
 
 					print '\n'.join([str('number_absent_genes: ' + str(number_absent_genes)), str('number_genes_multiple_alleles: ' + str(number_genes_multiple_alleles)), str('mean_sample_coverage: ' + str(round(mean_sample_coverage, 2)))])
 
-	utils.removeDirectory(rematch_folder)
+	if not debug_mode_true:
+		utils.removeDirectory(rematch_folder)
 
 	return run_successfully, sample_data if 'sample_data' in locals() else None, {'number_absent_genes': number_absent_genes, 'number_genes_multiple_alleles': number_genes_multiple_alleles, 'mean_sample_coverage': round(mean_sample_coverage, 2)} if 'number_absent_genes' in locals() else None, consensus_files

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -2,6 +2,7 @@ import os.path
 import multiprocessing
 import utils
 import functools
+import sys
 
 
 def index_fasta_samtools(fasta, region_None, region_outfile_none, print_comand_True):
@@ -191,7 +192,12 @@ def get_alt_noMatter(variant_position, indel_true):
 			alt = variant_position['ALT'][index_dominant_allele - 1]
 	else:
 		if float(variant_position['info']['IDV']) / float(dp) > 0.5:
-			alt = variant_position['ALT'][0]
+			index_dominant_allele = variant_position['format']['AD'].index(str(ad_idv))
+			if index_dominant_allele == 0:
+				sys.exit('Unexpected INDEL ALT coverage depth pattern found')
+				# alt = '.'
+			else:
+				alt = variant_position['ALT'][index_dominant_allele - 1]
 			ad_idv = int(variant_position['info']['IDV'])
 		else:
 			alt = '.'
@@ -674,11 +680,34 @@ def gather_data_together(sample, data_directory, sequences_information, outdir, 
 	return run_successfully, sample_data, consensus_files
 
 
+def clean_headers_reference_file(reference_file, outdir):
+	print 'Checking if reference sequences contain | or spaces'
+	headers_changed = False
+	new_reference_file = reference_file
+	sequences = get_sequence_information(reference_file)
+	for i in sequences:
+		if any(x in sequences[i]['header'] for x in ['|', ' ']):
+			for x in ['|', ' ']:
+				sequences[i]['header'] = sequences[i]['header'].replace(x, '_')
+			headers_changed = True
+	if headers_changed:
+		print 'At least one of the those characters was found. Replacing those with _'
+		new_reference_file = os.path.join(outdir, os.path.splitext(os.path.basename(reference_file))[0] + '.headers_renamed.fasta')
+		with open(new_reference_file, 'rt') as writer:
+			writer.write('>' + sequences[i]['header'] + '\n')
+			fasta_sequence_lines = chunkstring(sequences[i]['sequence'], 80)
+			for line in fasta_sequence_lines:
+				writer.write(line + '\n')
+	return new_reference_file
+
+
 rematch_timer = functools.partial(utils.timer, name='ReMatCh module')
 
 
 @rematch_timer
 def runRematchModule(sample, fastq_files, reference_file, threads, outdir, length_extra_seq, minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, minimum_gene_coverage, conserved_True, debug_mode_true):
+	reference_file = clean_headers_reference_file(reference_file, outdir)
+
 	rematch_folder = os.path.join(outdir, 'rematch_module', '')
 	utils.removeDirectory(rematch_folder)
 	os.mkdir(rematch_folder)

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -178,38 +178,32 @@ def indel_entry(variant_position):
 
 
 def get_alt_noMatter(variant_position, indel_true):
+	# dp = int(variant_position['info']['DP'])
 	dp = sum(map(int, variant_position['format']['AD']))
-	index_alleles_sorted_position = [(position, depth) for depth, position in sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)]
-	index_dominant_allele = index_alleles_sorted_position[0][0]
+	index_dominant_allele = None
 	if not indel_true:
-		ad_idv = index_alleles_sorted_position[0][1]
-		if float(ad_idv) / float(dp) >= 0.5:
-			if index_alleles_sorted_position[0][0] == 0:
-				if float(ad_idv) / float(dp) > 0.5:
-					alt = variant_position['ALT'][index_alleles_sorted_position[1][0] - 1]
-					index_dominant_allele = index_alleles_sorted_position[1][0]
-				else:
-					alt = 'N'
-					index_dominant_allele = None
-			else:
-				alt = variant_position['ALT'][index_alleles_sorted_position[0][0] - 1]
-		else:
+		ad_idv = max(map(int, variant_position['format']['AD']))
+
+		index_dominant_allele = variant_position['format']['AD'].index(str(ad_idv))
+
+		if index_dominant_allele == 0:
 			alt = '.'
+		else:
+			alt = variant_position['ALT'][index_dominant_allele - 1]
 	else:
-		ad_idv = int(variant_position['info']['IDV'])
-		if float(ad_idv) / float(dp) >= 0.5:
-			if index_alleles_sorted_position[0][0] == 0:
-				if float(ad_idv) / float(dp) > 0.5:
-					alt = variant_position['ALT'][index_alleles_sorted_position[1][0] - 1]
-					index_dominant_allele = index_alleles_sorted_position[1][0]
+		if float(variant_position['info']['IDV']) / float(dp) >= 0.5:
+			index_alleles_sorted_position = [position for depth, position in sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)]
+			if index_alleles_sorted_position[0] == 0:
+				if float(variant_position['info']['IDV']) / float(dp) > 0.5:
+					alt = variant_position['ALT'][index_alleles_sorted_position[1] - 1]
 				else:
-					alt = 'N'
-					index_dominant_allele = None
+					alt = '.'
 			else:
-				alt = variant_position['ALT'][index_alleles_sorted_position[0][0] - 1]
+				alt = variant_position['ALT'][index_alleles_sorted_position[0] - 1]
+			ad_idv = int(variant_position['info']['IDV'])
 		else:
 			alt = '.'
-			ad_idv = index_alleles_sorted_position[0][1]
+			ad_idv = max(map(int, variant_position['format']['AD']))
 
 	return alt, dp, ad_idv, index_dominant_allele
 

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -223,14 +223,17 @@ def get_alt_correct(variant_position, alt_noMatter, dp, ad_idv, index_dominant_a
 				if float(ad_idv) / float(dp) < minimum_depth_frequency_dominant_allele:
 					if index_dominant_allele is not None:
 						variants_coverage = [int(variant_position['format']['AD'][i]) for i in range(0, len(variant_position['ALT']) + 1) if i != index_dominant_allele]
-						if float(max(variants_coverage)) / float(sum(variants_coverage)) > 0.5:
-							multiple_alleles = True
-							alt = 'N' * len(variant_position['REF'])
-						elif float(max(variants_coverage)) / float(sum(variants_coverage)) == 0.5 and len(variants_coverage) > 2:
-							multiple_alleles = True
-							alt = 'N' * len(variant_position['REF'])
-						else:
+						if sum(variants_coverage) == 0:
 							alt = alt_noMatter
+						else:
+							if float(max(variants_coverage)) / float(sum(variants_coverage)) > 0.5:
+								multiple_alleles = True
+								alt = 'N' * len(variant_position['REF'])
+							elif float(max(variants_coverage)) / float(sum(variants_coverage)) == 0.5 and len(variants_coverage) > 2:
+								multiple_alleles = True
+								alt = 'N' * len(variant_position['REF'])
+							else:
+								alt = alt_noMatter
 					else:
 						multiple_alleles = True
 						alt = 'N' * len(variant_position['REF'])

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -2,7 +2,6 @@ import os.path
 import multiprocessing
 import utils
 import functools
-import sys
 
 
 def index_fasta_samtools(fasta, region_None, region_outfile_none, print_comand_True):
@@ -185,14 +184,6 @@ def get_alt_noMatter(variant_position, indel_true):
 	if not indel_true:
 		ad_idv = index_alleles_sorted_position[0][0]
 
-		# if len([x for x in index_alleles_sorted_position if x[0] == ad_idv]) > 1:
-		# 	alt = 'N'
-		# else:
-		# 	index_dominant_allele = index_alleles_sorted_position[0][1]
-		# 	if index_dominant_allele == 0:
-		# 		alt = '.'
-		# 	else:
-		# 		alt = variant_position['ALT'][index_dominant_allele - 1]
 		if len([x for x in index_alleles_sorted_position if x[0] == ad_idv]) > 1:
 			index_alleles_sorted_position = sorted([x for x in index_alleles_sorted_position if x[0] == ad_idv])
 
@@ -206,23 +197,15 @@ def get_alt_noMatter(variant_position, indel_true):
 		ad_idv = variant_position['info']['IDV']
 
 		if float(ad_idv) / float(dp) >= 0.5:
-			# if len([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]]) > 1:
-			# 	alt = 'N'
-			# else:
-			# 	index_dominant_allele = index_alleles_sorted_position[0][1]
-			# 	if index_dominant_allele == 0:
-			# 		alt = '.'
-			# 	else:
-			# 		alt = variant_position['ALT'][index_dominant_allele - 1]
 			if len([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]]) > 1:
 				index_alleles_sorted_position = sorted([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]])
+
 			index_dominant_allele = index_alleles_sorted_position[0][1]
 			if index_dominant_allele == 0:
 				alt = '.'
 			else:
 				alt = variant_position['ALT'][index_dominant_allele - 1]
 		else:
-			# ad_idv = max(map(int, variant_position['format']['AD']))
 			ad_idv = int(variant_position['format']['AD'][0])
 			alt = '.'
 

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -192,7 +192,7 @@ def get_alt_noMatter(variant_position, indel_true):
 			alt = variant_position['ALT'][index_dominant_allele - 1]
 	else:
 		if float(variant_position['info']['IDV']) / float(dp) > 0.5:
-			index_dominant_allele = variant_position['format']['AD'].index(str(ad_idv))
+			index_dominant_allele = variant_position['format']['AD'].index(str(max(map(int, variant_position['format']['AD']))))
 			if index_dominant_allele == 0:
 				sys.exit('Unexpected INDEL ALT coverage depth pattern found')
 				# alt = '.'

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -624,8 +624,8 @@ def chunkstring(string, length):
 def write_consensus(outdir, sample, consensus_sequence):
 	consensus_files = {}
 	for consensus_type in ['correct', 'noMatter', 'alignment']:
-		consensus_files[consensus_type] = sample + '.' + consensus_type + '.fasta'
-		with open(os.path.join(outdir, consensus_files[consensus_type]), 'at') as writer:
+		consensus_files[consensus_type] = os.path.join(outdir, str(sample + '.' + consensus_type + '.fasta'))
+		with open(consensus_files[consensus_type], 'at') as writer:
 			writer.write('>' + consensus_sequence[consensus_type]['header'] + '\n')
 			fasta_sequence_lines = chunkstring(consensus_sequence[consensus_type]['sequence'], 80)
 			for line in fasta_sequence_lines:

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -192,7 +192,7 @@ def get_alt_noMatter(variant_position, indel_true):
 			alt = variant_position['ALT'][index_dominant_allele - 1]
 	else:
 		if float(variant_position['info']['IDV']) / float(dp) >= 0.5:
-			index_alleles_sorted_position = [position for depth, position in sorted(zip(map(int(variant_position['format']['AD'])), range(0, len(variant_position['format']['AD']))))]
+			index_alleles_sorted_position = [position for depth, position in sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)]
 			if index_alleles_sorted_position[0] == 0:
 				if float(variant_position['info']['IDV']) / float(dp) > 0.5:
 					alt = variant_position['ALT'][index_alleles_sorted_position[1] - 1]

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -360,6 +360,9 @@ def get_true_variants(variants, minimum_depth_presence, minimum_depth_call, mini
 			if alt_alignment != '.':
 				variants_alignment[counter] = {'REF': ref, 'ALT': alt_alignment}
 
+			if alt_noMatter != '.':
+				variants_noMatter[counter] = {'REF': ref, 'ALT': alt_noMatter}
+
 			if alt_correct is None:
 				if counter - len(last_absent_position) in absent_positions:
 					absent_positions[counter - len(last_absent_position)]['REF'] += ref
@@ -367,9 +370,6 @@ def get_true_variants(variants, minimum_depth_presence, minimum_depth_call, mini
 					absent_positions[counter] = {'REF': ref, 'ALT': ''}
 				last_absent_position += ref
 			else:
-				if alt_noMatter != '.':
-					variants_noMatter[counter] = {'REF': ref, 'ALT': alt_noMatter}
-
 				if alt_correct != '.':
 					if len(alt_correct) < len(ref):
 						if len(alt_correct) == 1:
@@ -401,17 +401,19 @@ def get_true_variants(variants, minimum_depth_presence, minimum_depth_call, mini
 	for position in absent_positions:
 		if position == 1:
 			variants_correct[position] = {'REF': absent_positions[position]['REF'], 'ALT': 'N'}
-			variants_noMatter[position] = {'REF': absent_positions[position]['REF'], 'ALT': 'N'}
+			if position not in variants:
+				variants_noMatter[position] = {'REF': absent_positions[position]['REF'], 'ALT': 'N'}
 		else:
 			if position - 1 not in variants_correct:
 				variants_correct[position - 1] = {'REF': sequence[position - 2] + absent_positions[position]['REF'], 'ALT': sequence[position - 2] + absent_positions[position]['ALT']}
 			else:
 				variants_correct[position - 1] = {'REF': variants_correct[position - 1]['REF'] + absent_positions[position]['REF'][len(variants_correct[position - 1]['REF']) - 1:], 'ALT': variants_correct[position - 1]['ALT'] + absent_positions[position]['ALT'][len(variants_correct[position - 1]['ALT']) - 1 if len(variants_correct[position - 1]['ALT']) > 0 else 0:]}
 
-			if position - 1 not in variants_noMatter:
-				variants_noMatter[position - 1] = {'REF': sequence[position - 2] + absent_positions[position]['REF'], 'ALT': sequence[position - 2] + absent_positions[position]['ALT']}
-			else:
-				variants_noMatter[position - 1] = {'REF': variants_noMatter[position - 1]['REF'] + absent_positions[position]['REF'][len(variants_noMatter[position - 1]['REF']) - 1:], 'ALT': variants_noMatter[position - 1]['ALT'] + absent_positions[position]['ALT'][len(variants_noMatter[position - 1]['ALT']) - 1 if len(variants_noMatter[position - 1]['ALT']) > 0 else 0:]}
+			if position not in variants:
+				if position - 1 not in variants_noMatter:
+					variants_noMatter[position - 1] = {'REF': sequence[position - 2] + absent_positions[position]['REF'], 'ALT': sequence[position - 2] + absent_positions[position]['ALT']}
+				else:
+					variants_noMatter[position - 1] = {'REF': variants_noMatter[position - 1]['REF'] + absent_positions[position]['REF'][len(variants_noMatter[position - 1]['REF']) - 1:], 'ALT': variants_noMatter[position - 1]['ALT'] + absent_positions[position]['ALT'][len(variants_noMatter[position - 1]['ALT']) - 1 if len(variants_noMatter[position - 1]['ALT']) > 0 else 0:]}
 
 	return variants_correct, variants_noMatter, variants_alignment, multiple_alleles_found
 

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -306,7 +306,10 @@ def snp_indel(variants, position, minimum_depth_presence, minimum_depth_call, mi
 	else:
 		ref, alt_correct_snp, low_coverage, multiple_alleles, alt_noMatter_snp, alt_alignment_snp = determine_variant(variants[position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 
-		indel_more_likely = get_indel_more_likely(variants[position], entry_with_indel)
+		indel_more_likely = entry_with_indel[0]
+		if len(entry_with_indel) > 1:
+			indel_more_likely = get_indel_more_likely(variants[position], entry_with_indel)
+
 		ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[position][entry_with_indel[indel_more_likely]], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, True)
 
 		if alt_noMatter == '.':

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -222,7 +222,7 @@ def get_alt_correct(variant_position, alt_noMatter, dp, ad_idv, index_dominant_a
 			else:
 				if float(ad_idv) / float(dp) < minimum_depth_frequency_dominant_allele:
 					if index_dominant_allele is not None:
-						variants_coverage = [int(variant_position['format']['AD'][i]) for i in range(0, len([j for j in variant_position['ALT'] if j != '<*>']) + 1) if i != index_dominant_allele]
+						variants_coverage = [int(variant_position['format']['AD'][i]) for i in range(0, len(variant_position['ALT']) + 1) if i != index_dominant_allele]
 						if float(max(variants_coverage)) / float(sum(variants_coverage)) > 0.5:
 							multiple_alleles = True
 							alt = 'N' * len(variant_position['REF'])

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -180,37 +180,47 @@ def indel_entry(variant_position):
 def get_alt_noMatter(variant_position, indel_true):
 	# dp = int(variant_position['info']['DP'])
 	dp = sum(map(int, variant_position['format']['AD']))
-	index_alleles_sorted_position = [sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)]
+	index_alleles_sorted_position = sorted(zip(map(int, variant_position['format']['AD']), range(0, len(variant_position['format']['AD']))), reverse=True)
 	index_dominant_allele = None
 	if not indel_true:
 		ad_idv = index_alleles_sorted_position[0][0]
 
+		# if len([x for x in index_alleles_sorted_position if x[0] == ad_idv]) > 1:
+		# 	alt = 'N'
+		# else:
+		# 	index_dominant_allele = index_alleles_sorted_position[0][1]
+		# 	if index_dominant_allele == 0:
+		# 		alt = '.'
+		# 	else:
+		# 		alt = variant_position['ALT'][index_dominant_allele - 1]
 		if len([x for x in index_alleles_sorted_position if x[0] == ad_idv]) > 1:
-			alt = 'N'
+			index_alleles_sorted_position = sorted([x for x in index_alleles_sorted_position if x[0] == ad_idv])
+
+		index_dominant_allele = index_alleles_sorted_position[0][1]
+		if index_dominant_allele == 0:
+			alt = '.'
 		else:
+			alt = variant_position['ALT'][index_dominant_allele - 1]
+
+	else:
+		ad_idv = variant_position['info']['IDV']
+
+		if float(ad_idv) / float(dp) >= 0.5:
+			# if len([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]]) > 1:
+			# 	alt = 'N'
+			# else:
+			# 	index_dominant_allele = index_alleles_sorted_position[0][1]
+			# 	if index_dominant_allele == 0:
+			# 		alt = '.'
+			# 	else:
+			# 		alt = variant_position['ALT'][index_dominant_allele - 1]
+			if len([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]]) > 1:
+				index_alleles_sorted_position = sorted([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]])
 			index_dominant_allele = index_alleles_sorted_position[0][1]
 			if index_dominant_allele == 0:
 				alt = '.'
 			else:
 				alt = variant_position['ALT'][index_dominant_allele - 1]
-	else:
-		ad_idv = variant_position['info']['IDV']
-
-		if float(ad_idv) / float(dp) >= 0.5:
-			# depth = index_alleles_sorted_position[0][0] if float(ad_idv) / float(dp) > 0.5 else ad_idv
-			if len([x for x in index_alleles_sorted_position if x[0] == index_alleles_sorted_position[0][0]]) > 1:
-				alt = 'N'
-			else:
-				index_dominant_allele = index_alleles_sorted_position[0][1]
-				if index_dominant_allele == 0:
-					alt = '.'
-				else:
-					alt = variant_position['ALT'][index_dominant_allele - 1]
-		# elif float(ad_idv) / float(dp) == 0.5:
-		# 	if len([x for x in index_alleles_sorted_position if x[0] == ad_idv]) > 1:
-		# 		alt = 'N'
-		# 	else:
-		# 		pass
 		else:
 			# ad_idv = max(map(int, variant_position['format']['AD']))
 			ad_idv = int(variant_position['format']['AD'][0])

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -294,6 +294,10 @@ def confirm_nucleotides_indel(ref, alt, variants, position_start_indel, minimum_
 				break
 			new_position = position_start_indel + 1 + i
 
+		if new_position not in variants:
+			alt[1 + i] = ''
+			continue
+
 		entry_with_indel, entry_with_snp = indel_entry(variants[new_position])
 		new_ref, alt_correct, low_coverage, multiple_alleles, alt_noMatter, alt_alignment = determine_variant(variants[new_position][entry_with_snp], minimum_depth_presence, minimum_depth_call, minimum_depth_frequency_dominant_allele, False)
 		if alt_noMatter != '.' and alt[1 + i] != alt_noMatter:

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -366,9 +366,6 @@ def get_true_variants(variants, minimum_depth_presence, minimum_depth_call, mini
 			if alt_alignment != '.':
 				variants_alignment[counter] = {'REF': ref, 'ALT': alt_alignment}
 
-			if alt_noMatter != '.':
-				variants_noMatter[counter] = {'REF': ref, 'ALT': alt_noMatter}
-
 			if alt_correct is None:
 				if counter - len(last_absent_position) in absent_positions:
 					absent_positions[counter - len(last_absent_position)]['REF'] += ref
@@ -376,6 +373,9 @@ def get_true_variants(variants, minimum_depth_presence, minimum_depth_call, mini
 					absent_positions[counter] = {'REF': ref, 'ALT': ''}
 				last_absent_position += ref
 			else:
+				if alt_noMatter != '.':
+					variants_noMatter[counter] = {'REF': ref, 'ALT': alt_noMatter}
+
 				if alt_correct != '.':
 					if len(alt_correct) < len(ref):
 						if len(alt_correct) == 1:
@@ -407,19 +407,17 @@ def get_true_variants(variants, minimum_depth_presence, minimum_depth_call, mini
 	for position in absent_positions:
 		if position == 1:
 			variants_correct[position] = {'REF': absent_positions[position]['REF'], 'ALT': 'N'}
-			if position not in variants:
-				variants_noMatter[position] = {'REF': absent_positions[position]['REF'], 'ALT': 'N'}
+			variants_noMatter[position] = {'REF': absent_positions[position]['REF'], 'ALT': 'N'}
 		else:
 			if position - 1 not in variants_correct:
 				variants_correct[position - 1] = {'REF': sequence[position - 2] + absent_positions[position]['REF'], 'ALT': sequence[position - 2] + absent_positions[position]['ALT']}
 			else:
 				variants_correct[position - 1] = {'REF': variants_correct[position - 1]['REF'] + absent_positions[position]['REF'][len(variants_correct[position - 1]['REF']) - 1:], 'ALT': variants_correct[position - 1]['ALT'] + absent_positions[position]['ALT'][len(variants_correct[position - 1]['ALT']) - 1 if len(variants_correct[position - 1]['ALT']) > 0 else 0:]}
 
-			if position not in variants:
-				if position - 1 not in variants_noMatter:
-					variants_noMatter[position - 1] = {'REF': sequence[position - 2] + absent_positions[position]['REF'], 'ALT': sequence[position - 2] + absent_positions[position]['ALT']}
-				else:
-					variants_noMatter[position - 1] = {'REF': variants_noMatter[position - 1]['REF'] + absent_positions[position]['REF'][len(variants_noMatter[position - 1]['REF']) - 1:], 'ALT': variants_noMatter[position - 1]['ALT'] + absent_positions[position]['ALT'][len(variants_noMatter[position - 1]['ALT']) - 1 if len(variants_noMatter[position - 1]['ALT']) > 0 else 0:]}
+			if position - 1 not in variants_noMatter:
+				variants_noMatter[position - 1] = {'REF': sequence[position - 2] + absent_positions[position]['REF'], 'ALT': sequence[position - 2] + absent_positions[position]['ALT']}
+			else:
+				variants_noMatter[position - 1] = {'REF': variants_noMatter[position - 1]['REF'] + absent_positions[position]['REF'][len(variants_noMatter[position - 1]['REF']) - 1:], 'ALT': variants_noMatter[position - 1]['ALT'] + absent_positions[position]['ALT'][len(variants_noMatter[position - 1]['ALT']) - 1 if len(variants_noMatter[position - 1]['ALT']) > 0 else 0:]}
 
 	return variants_correct, variants_noMatter, variants_alignment, multiple_alleles_found
 

--- a/modules/rematch_module.py
+++ b/modules/rematch_module.py
@@ -612,7 +612,7 @@ def sequence_data(sample, reference_file, bam_file, outdir, threads, length_extr
 	pool.close()
 	pool.join()
 
-	run_successfully, sample_data, consensus_files = gather_data_together(sample, sequence_data_outdir, sequences, outdir.rsplit('/', 2)[0])
+	run_successfully, sample_data, consensus_files = gather_data_together(sample, sequence_data_outdir, sequences, outdir.rsplit('/', 2)[0], debug_mode_true)
 
 	return run_successfully, sample_data, consensus_files
 

--- a/rematch.py
+++ b/rematch.py
@@ -198,7 +198,7 @@ def concatenate_extraSeq_2_consensus(consensus_sequence, reference_sequence, ext
 
 
 def clean_headers_reference_file(reference_file, outdir):
-	problematic_characters = ['|', ' ', ',', '.', '(', ')', "'", '/']
+	problematic_characters = ["|", " ", ",", ".", "(", ")", "'", "/"]
 	print 'Checking if reference sequences contain ' + str(problematic_characters) + '\n'
 	headers_changed = False
 	new_reference_file = reference_file

--- a/rematch.py
+++ b/rematch.py
@@ -273,7 +273,7 @@ def runRematch(args):
 			# Run ReMatCh
 			time_taken_rematch_first, run_successfully_rematch_first, data_by_gene, sample_data_general_first, consensus_files = rematch_module.runRematchModule(sample, fastq_files, reference_file, args.threads, sample_outdir, args.extraSeq, args.minCovPresence, args.minCovCall, args.minFrequencyDominantAllele, args.minGeneCoverage, args.conservedSeq, args.debug)
 			if run_successfully_rematch_first:
-				genes_first = write_data_by_gene(genes_first, args.minGeneCoverage, sample, data_by_gene, workdir, time_str, 'first_time')
+				genes_first = write_data_by_gene(genes_first, args.minGeneCoverage, sample, data_by_gene, workdir, time_str, 'first_run')
 				if args.doubleRun:
 					rematch_second_outdir = os.path.join(sample_outdir, 'rematch_second_run', '')
 					if not os.path.isdir(rematch_second_outdir):
@@ -283,7 +283,7 @@ def runRematch(args):
 					if not args.debug:
 						os.remove(consensus_concatenated_fasta)
 					if run_successfully_rematch_second:
-						genes_second = write_data_by_gene(genes_second, args.minGeneCoverage, sample, data_by_gene, workdir, time_str, 'second_time')
+						genes_second = write_data_by_gene(genes_second, args.minGeneCoverage, sample, data_by_gene, workdir, time_str, 'second_run')
 
 		if not searched_fastq_files and not args.keepDownloadedFastq and fastq_files is not None:
 			for fastq in fastq_files:
@@ -318,7 +318,7 @@ def main():
 	parser_optional_rematch.add_argument('--minCovCall', type=int, metavar='N', help='Reference position minimum coverage depth to perform a base call. Lower coverage will be coded as N', required=False, default=10)
 	parser_optional_rematch.add_argument('--minFrequencyDominantAllele', type=float, metavar='0.6', help='Minimum relative frequency of the dominant allele coverage depth (value between [0, 1]). Positions with lower values will be considered as having multiple alleles (and will be coded as N)', required=False, default=0.6)
 	parser_optional_rematch.add_argument('--minGeneCoverage', type=int, metavar='N', help='Minimum percentage of target reference gene sequence covered by --minCovPresence to consider a gene to be present (value between [0, 100])', required=False, default=80)
-	parser_optional_rematch.add_argument('--doubleRun', action='store_true', help='Tells ReMatCh to run a second time using as reference sequence the consensus sequence produced in the first time')
+	parser_optional_rematch.add_argument('--doubleRun', action='store_true', help='Tells ReMatCh to run a second time using as reference the noMatter consensus sequence produced in the first run. This will improve consensus sequence determination for sequences with high percentage of target reference gene sequence covered')
 	parser_optional_rematch.add_argument('--debug', action='store_true', help='DeBug Mode: do not remove temporary files')
 
 	parser_optional_download = parser.add_argument_group('Download facultative options')

--- a/rematch.py
+++ b/rematch.py
@@ -198,7 +198,7 @@ def concatenate_extraSeq_2_consensus(consensus_sequence, reference_sequence, ext
 
 
 def clean_headers_reference_file(reference_file, outdir):
-	problematic_characters = ['|', ' ', ',', '.']
+	problematic_characters = ['|', ' ', ',', '.', '(', ')', "'", '/']
 	print 'Checking if reference sequences contain ' + str(problematic_characters) + '\n'
 	headers_changed = False
 	new_reference_file = reference_file
@@ -212,10 +212,11 @@ def clean_headers_reference_file(reference_file, outdir):
 		print 'At least one of the those characters was found. Replacing those with _' + '\n'
 		new_reference_file = os.path.join(outdir, os.path.splitext(os.path.basename(reference_file))[0] + '.headers_renamed.fasta')
 		with open(new_reference_file, 'wt') as writer:
-			writer.write('>' + sequences[i]['header'] + '\n')
-			fasta_sequence_lines = rematch_module.chunkstring(sequences[i]['sequence'], 80)
-			for line in fasta_sequence_lines:
-				writer.write(line + '\n')
+			for i in sequences:
+				writer.write('>' + sequences[i]['header'] + '\n')
+				fasta_sequence_lines = rematch_module.chunkstring(sequences[i]['sequence'], 80)
+				for line in fasta_sequence_lines:
+					writer.write(line + '\n')
 	return new_reference_file
 
 

--- a/rematch.py
+++ b/rematch.py
@@ -144,8 +144,8 @@ def format_gene_info(gene_specific_info, minimum_gene_coverage):
 	return info
 
 
-def write_data_by_gene(genes_list, minimum_gene_coverage, sample, data_by_gene, outdir, time_str):
-	combined_report = os.path.join(outdir, 'combined_report.data_by_gene.' + time_str + '.tab')
+def write_data_by_gene(genes_list, minimum_gene_coverage, sample, data_by_gene, outdir, time_str, run_times):
+	combined_report = os.path.join(outdir, 'combined_report.data_by_gene.' + run_times + '.' + time_str + '.tab')
 	with open(combined_report, 'at') as writer:
 		if len(genes_list) == 0:
 			genes_list = [data_by_gene[i]['header'] for i in data_by_gene]
@@ -162,19 +162,19 @@ def write_data_by_gene(genes_list, minimum_gene_coverage, sample, data_by_gene, 
 	return genes_list
 
 
-def write_sample_report(sample, outdir, time_str, run_successfully_fastq, run_successfully_rematch, time_taken_fastq, time_taken_rematch, time_taken_sample, sequencingInformation, sample_data_general, fastq_used):
+def write_sample_report(sample, outdir, time_str, run_successfully_fastq, run_successfully_rematch_first, run_successfully_rematch_second, time_taken_fastq, time_taken_rematch_first, time_taken_rematch_second, time_taken_sample, sequencingInformation, sample_data_general_first, sample_data_general_second, fastq_used):
 	sample_report = os.path.join(outdir, 'sample_report.' + time_str + '.tab')
 	report_exist = os.path.isfile(sample_report)
 
-	header_general = ['sample', 'sample_run_successfully', 'sample_run_time', 'download_run_successfully', 'download_run_time', 'rematch_run_successfully', 'rematch_run_time']
+	header_general = ['sample', 'sample_run_successfully', 'sample_run_time', 'download_run_successfully', 'download_run_time', 'rematch_run_successfully_first', 'rematch_run_successfully_second', 'rematch_run_time_first', 'rematch_run_time_second']
 	header_data_general = ['number_absent_genes', 'number_genes_multiple_alleles', 'mean_sample_coverage']
 	header_sequencing = ['run_accession', 'instrument_platform', 'instrument_model', 'library_layout', 'library_source', 'extra_run_accession', 'date_download']
 
 	with open(sample_report, 'at') as writer:
 		if not report_exist:
-			writer.write('#' + '\t'.join(header_general) + '\t' + '\t'.join(header_data_general) + '\t' + '\t'.join(header_sequencing) + '\t' + 'fastq_used' + '\n')
+			writer.write('#' + '\t'.join(header_general) + '\t' + '_first\t'.join(header_data_general) + '_first\t' + '_second\t'.join(header_data_general) + '_second\t' + '\t'.join(header_sequencing) + '\t' + 'fastq_used' + '\n')
 
-		writer.write('\t'.join([sample, str(all([run_successfully_fastq, run_successfully_rematch])), str(time_taken_sample), str(run_successfully_fastq), str(time_taken_fastq), str(run_successfully_rematch), str(time_taken_rematch)]) + '\t' + '\t'.join([str(sample_data_general[i]) for i in header_data_general]) + '\t' + '\t'.join([str(sequencingInformation[i]) for i in header_sequencing]) + '\t' + ','.join(fastq_used) + '\n')
+		writer.write('\t'.join([sample, str(all([run_successfully_fastq is not False, run_successfully_rematch_first is not False, run_successfully_rematch_second is not False])), str(time_taken_sample), str(run_successfully_fastq), str(time_taken_fastq), str(run_successfully_rematch_first), str(time_taken_rematch_first), str(run_successfully_rematch_second), str(time_taken_rematch_second)]) + '\t' + '\t'.join([str(sample_data_general_first[i]) for i in header_data_general]) + '\t' + '\t'.join([str(sample_data_general_second[i]) for i in header_data_general]) + '\t' + '\t'.join([str(sequencingInformation[i]) for i in header_sequencing]) + '\t' + ','.join(fastq_used) + '\n')
 
 
 def concatenate_extraSeq_2_consensus(consensus_sequence, reference_sequence, extraSeq_length, outdir):
@@ -229,7 +229,7 @@ def runRematch(args):
 		if not os.path.isdir(sample_outdir):
 			os.mkdir(sample_outdir)
 
-		run_successfully_fastq = False
+		run_successfully_fastq = None
 		time_taken_fastq = 0
 		sequencingInformation = {'run_accession': None, 'instrument_platform': None, 'instrument_model': None, 'library_layout': None, 'library_source': None, 'extra_run_accession': None, 'date_download': None}
 		if not searched_fastq_files:
@@ -237,20 +237,22 @@ def runRematch(args):
 			time_taken_fastq, run_successfully_fastq, fastq_files, sequencingInformation = download.runDownload(sample, args.downloadLibrariesType, asperaKey, sample_outdir, args.downloadCramBam, args.threads, args.downloadInstrumentPlatform)
 		else:
 			fastq_files = listIDs[sample]
-			run_successfully_fastq = True
 
-		run_successfully_rematch = False
-		time_taken_rematch = 0
-		if run_successfully_fastq:
+		run_successfully_rematch_first = None
+		run_successfully_rematch_second = None
+		time_taken_rematch_first = 0
+		time_taken_rematch_second = 0
+		if run_successfully_fastq is not False:
 			# Run ReMatCh
-			time_taken_rematch, run_successfully_rematch, data_by_gene, sample_data_general, consensus_files = rematch_module.runRematchModule(sample, fastq_files, os.path.abspath(args.reference.name), args.threads, sample_outdir, args.extraSeq, args.minCovPresence, args.minCovCall, args.minFrequencyDominantAllele, args.minGeneCoverage, args.conservedSeq)
-			if run_successfully_rematch:
+			time_taken_rematch_first, run_successfully_rematch_first, data_by_gene, sample_data_general_first, consensus_files = rematch_module.runRematchModule(sample, fastq_files, os.path.abspath(args.reference.name), args.threads, sample_outdir, args.extraSeq, args.minCovPresence, args.minCovCall, args.minFrequencyDominantAllele, args.minGeneCoverage, args.conservedSeq, args.debug)
+			if run_successfully_rematch_first:
+				genes = write_data_by_gene(genes, args.minGeneCoverage, sample, data_by_gene, workdir, time_str, 'first_time')
 				if args.doubleRun:
 					consensus_concatenated_fasta = concatenate_extraSeq_2_consensus(consensus_files['noMatter'], os.path.abspath(args.reference.name), args.extraSeq, sample_outdir)
-					time_taken_rematch, run_successfully_rematch, data_by_gene, sample_data_general, consensus_files = rematch_module.runRematchModule(sample, fastq_files, consensus_concatenated_fasta, args.threads, sample_outdir, args.extraSeq, args.minCovPresence, args.minCovCall, args.minFrequencyDominantAllele, args.minGeneCoverage, args.conservedSeq)
+					time_taken_rematch_second, run_successfully_rematch_second, data_by_gene, sample_data_general_second, consensus_files = rematch_module.runRematchModule(sample, fastq_files, consensus_concatenated_fasta, args.threads, sample_outdir, args.extraSeq, args.minCovPresence, args.minCovCall, args.minFrequencyDominantAllele, args.minGeneCoverage, args.conservedSeq, args.debug)
 					os.remove(consensus_concatenated_fasta)
-			if run_successfully_rematch:
-				genes = write_data_by_gene(genes, args.minGeneCoverage, sample, data_by_gene, workdir, time_str)
+					if run_successfully_rematch_second:
+						genes = write_data_by_gene(genes, args.minGeneCoverage, sample, data_by_gene, workdir, time_str, 'second_time')
 
 		if not searched_fastq_files and not args.keepDownloadedFastq and fastq_files is not None:
 			for fastq in fastq_files:
@@ -258,9 +260,9 @@ def runRematch(args):
 
 		time_taken = utils.runTime(sample_start_time)
 
-		write_sample_report(sample, workdir, time_str, run_successfully_fastq, run_successfully_rematch, time_taken_fastq, time_taken_rematch, time_taken, sequencingInformation, sample_data_general if run_successfully_rematch else {'number_absent_genes': None, 'number_genes_multiple_alleles': None, 'mean_sample_coverage': None}, fastq_files if fastq_files is not None else '')
+		write_sample_report(sample, workdir, time_str, run_successfully_fastq, run_successfully_rematch_first, run_successfully_rematch_second, time_taken_fastq, time_taken_rematch_first, time_taken_rematch_second, time_taken, sequencingInformation, sample_data_general_first if run_successfully_rematch_first else {'number_absent_genes': None, 'number_genes_multiple_alleles': None, 'mean_sample_coverage': None}, sample_data_general_second if run_successfully_rematch_second else {'number_absent_genes': None, 'number_genes_multiple_alleles': None, 'mean_sample_coverage': None}, fastq_files if fastq_files is not None else '')
 
-		if all([run_successfully_fastq, run_successfully_rematch]):
+		if all([run_successfully_fastq is not False, run_successfully_rematch_first is not False, run_successfully_rematch_second is not False]):
 			number_samples_successfully += 1
 
 	return number_samples_successfully, len(listIDs)
@@ -286,6 +288,7 @@ def main():
 	parser_optional_rematch.add_argument('--minFrequencyDominantAllele', type=float, metavar='0.6', help='Minimum relative frequency of the dominant allele coverage depth (value between [0, 1]). Positions with lower values will be considered as having multiple alleles (and will be coded as N)', required=False, default=0.6)
 	parser_optional_rematch.add_argument('--minGeneCoverage', type=int, metavar='N', help='Minimum percentage of target reference gene sequence covered by --minCovPresence to consider a gene to be present (value between [0, 100])', required=False, default=80)
 	parser_optional_rematch.add_argument('--doubleRun', action='store_true', help='Tells ReMatCh to run a second time using as reference sequence the consensus sequence produced in the first time')
+	parser_optional_rematch.add_argument('--debug', action='store_true', help='DeBug Mode: do not remove temporary files')
 
 	parser_optional_download = parser.add_argument_group('Download facultative options')
 	parser_optional_download.add_argument('-a', '--asperaKey', type=argparse.FileType('r'), metavar='/path/to/asperaweb_id_dsa.openssh', help='Tells ReMatCh to download fastq files from ENA using Aspera Connect. With this option, the path to Private-key file asperaweb_id_dsa.openssh must be provided (normaly found in ~/.aspera/connect/etc/asperaweb_id_dsa.openssh).', required=False)

--- a/rematch.py
+++ b/rematch.py
@@ -203,14 +203,15 @@ def clean_headers_reference_file(reference_file, outdir):
 	new_reference_file = reference_file
 	sequences = rematch_module.get_sequence_information(reference_file)
 	for i in sequences:
-		if any(x in sequences[i]['header'] for x in ['|', ' ']):
-			for x in ['|', ' ']:
+		problematic_characters = ['|', ' ', ',', '.']
+		if any(x in sequences[i]['header'] for x in problematic_characters):
+			for x in problematic_characters:
 				sequences[i]['header'] = sequences[i]['header'].replace(x, '_')
 			headers_changed = True
 	if headers_changed:
-		print 'At least one of the those characters was found. Replacing those with _'
+		print 'At least one of the those characters was found. Replacing those with _' + '\n'
 		new_reference_file = os.path.join(outdir, os.path.splitext(os.path.basename(reference_file))[0] + '.headers_renamed.fasta')
-		with open(new_reference_file, 'rt') as writer:
+		with open(new_reference_file, 'wt') as writer:
 			writer.write('>' + sequences[i]['header'] + '\n')
 			fasta_sequence_lines = rematch_module.chunkstring(sequences[i]['sequence'], 80)
 			for line in fasta_sequence_lines:

--- a/rematch.py
+++ b/rematch.py
@@ -9,7 +9,7 @@ and consensus sequences production
 
 Copyright (C) 2016 Miguel Machado <mpmachado@medicina.ulisboa.pt>
 
-Last modified: December 07, 2016
+Last modified: January 10, 2017
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ import modules.download as download
 import modules.rematch_module as rematch_module
 
 
-version = '2.0'
+version = '3.0'
 
 
 def searchFastqFiles(directory):

--- a/rematch.py
+++ b/rematch.py
@@ -198,12 +198,12 @@ def concatenate_extraSeq_2_consensus(consensus_sequence, reference_sequence, ext
 
 
 def clean_headers_reference_file(reference_file, outdir):
-	print 'Checking if reference sequences contain | or spaces' + '\n'
+	problematic_characters = ['|', ' ', ',', '.']
+	print 'Checking if reference sequences contain ' + str(problematic_characters) + '\n'
 	headers_changed = False
 	new_reference_file = reference_file
 	sequences = rematch_module.get_sequence_information(reference_file)
 	for i in sequences:
-		problematic_characters = ['|', ' ', ',', '.']
 		if any(x in sequences[i]['header'] for x in problematic_characters):
 			for x in problematic_characters:
 				sequences[i]['header'] = sequences[i]['header'].replace(x, '_')


### PR DESCRIPTION
Add `--doubleRun` to tell ReMatCh to run a second time using as reference the noMatter consensus sequence produced in the first run.
Add `--debug` to not remove temporary files
Clean sequence headers (replace "|", " ", ",", ".", "(", ")", "'" and "/" for "_")
Change variants determination